### PR TITLE
feat: add theme toggle and dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,18 +5,23 @@
   --foreground: #171717;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --background: #0a0a0a;
+    --foreground: #ededed;
+  }
+}
+
+[data-theme="dark"] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import MiniCartDrawer from "@/components/MiniCartDrawer";
 import Toasts from "@/components/Toasts";
+import { ThemeProvider } from "next-themes";
 
 export const metadata: Metadata = {
   // ใช้ URL โปรดักชันถ้ามี (เช่นจาก .env) ไม่งั้น fallback เป็น localhost
@@ -40,17 +41,23 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="th" suppressHydrationWarning>
-      <body className="min-h-dvh bg-gray-50 text-gray-900">
+      <body className="min-h-dvh bg-background text-foreground">
+        <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
           <Navbar />
           <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
           <Footer />
           <MiniCartDrawer />
           <Toasts />
+        </ThemeProvider>
         {/* JSON-LD site-wide */}
-        <script type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }} />
-        <script type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }}
+        />
       </body>
     </html>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
-    <footer className="border-t bg-white">
-      <div className="mx-auto max-w-6xl px-4 py-8 text-xs text-gray-500">
+    <footer className="border-t border-foreground/20 bg-background">
+      <div className="mx-auto max-w-6xl px-4 py-8 text-xs text-foreground/60">
         © {new Date().getFullYear()} Mini Shop — All rights reserved.
       </div>
     </footer>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,28 +3,31 @@
 import Link from "next/link";
 import { useCartTotals } from "@/stores/cart";
 import { useUI } from "@/stores/ui";
+import ThemeToggle from "@/components/ThemeToggle";
 
 export default function Navbar() {
   const { totalCount } = useCartTotals();
   const { openCart } = useUI();
 
   return (
-    <header className="border-b bg-black">
+    <header className="border-b border-foreground/20 bg-background">
       <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
         <Link href="/" className="font-semibold">Mini Shop</Link>
         <ul className="flex items-center gap-6 text-sm">
           <li><Link href="/">Home</Link></li>
           <li><Link href="/products">Products</Link></li>
           <li>
-            <button onClick={openCart} className="relative inline-flex items-center ">
+            <button onClick={openCart} className="relative inline-flex items-center">
               Cart
               {totalCount > 0 && (
-                <span className="ml-2 inline-flex min-w-5 items-center justify-center rounded-full bg-black px-1.5 text-[10px] font-semibold text-white">
+                <span className="ml-2 inline-flex min-w-5 items-center justify-center rounded-full bg-foreground px-1.5 text-[10px] font-semibold text-background">
                   {totalCount}
                 </span>
               )}
             </button>
-            
+          </li>
+          <li>
+            <ThemeToggle />
           </li>
         </ul>
       </nav>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  const isDark = theme === "dark";
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      {isDark ? "☀️" : "🌙"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add client-side theme toggle powered by `next-themes`
- wire global colors through Tailwind tokens and apply them across layout and navigation

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac9ccdaf90832cb5882c187f9c41b4